### PR TITLE
Multi Paired Tracks & Special Tracks

### DIFF
--- a/resources/snes/metroid3/manifests/tracks.json
+++ b/resources/snes/metroid3/manifests/tracks.json
@@ -286,7 +286,7 @@
         "notes": [
           "Mother Brain 3"
         ],
-        "description": "Extended track that plays during the Mother Brain battle after receiving the Hyper Beam from the baby Metroid. If not present, the Theme of Samus Aran will be played."
+        "description": "Extended track that plays during the Mother Brain battle after receiving the Hyper Beam from the baby Metroid. If not present, the Samus' Ship theme will be played."
       },
       {
         "title": "Game Over",

--- a/resources/snes/metroid3/manifests/tracks.json
+++ b/resources/snes/metroid3/manifests/tracks.json
@@ -8,11 +8,13 @@
         "title": "File Start",
         "name": "Samus Aran's Appearance Fanfare",
         "nonlooping": true,
+        "special_track": true,
         "description": "Song played when first starting at the ship or a save station before you can start moving. Does not loop and plays for about 8 seconds."
       },
       {
         "title": "Item Acquisition Fanfare",
         "nonlooping": true,
+        "special_track": true,
         "description": "Song played when you retrieve an item. Does not loop and plays for 6-7 seconds. Not used in SMZ3."
       },
       {
@@ -35,12 +37,16 @@
       },
       {
         "title": "Opening with intro",
-        "pair": 5,
+        "paired_tracks": [
+          5
+        ],
         "description": "Song played right when first booting up the game and continues into the game title screen if the player doesn't press any buttons. There are around 24 seconds before the game title appears."
       },
       {
         "title": "Opening without intro",
-        "pair": 4,
+        "paired_tracks": [
+          4
+        ],
         "description": "Song played if the player presses any buttons to skip to the game title screen before it displays the title screen normally."
       },
       {
@@ -140,7 +146,9 @@
       },
       {
         "title": "Big Boss Battle 2",
-        "pair": 23,
+        "paired_tracks": [
+          23
+        ],
         "notes": [
           "Boss Battle Theme",
           "Crocomire, Kraid, Phantoon, The Baby",
@@ -151,7 +159,9 @@
       },
       {
         "title": "Tension / Hostile Incoming",
-        "pair": 22,
+        "paired_tracks": [
+          22
+        ],
         "notes": [
           "Boss Incoming Theme",
           "Crocomire intermission, pre-Kraid, pre-Phantoon, pre-The Baby",
@@ -189,6 +199,7 @@
       {
         "title": "Death Cry",
         "nonlooping": true,
+        "special_track": true,
         "description": "Song played during Samus's death animation. Lasts about 4 seconds long with 2 seconds for Samus to power down and the rest to explode. Does not loop."
       },
       {
@@ -203,7 +214,9 @@
     "extended": [
       {
         "title": "Kraid Incoming",
-        "pair": 32,
+        "paired_tracks": [
+          32
+        ],
         "fallback": 23,
         "notes": [
           "Baby-Kraid Room",
@@ -213,19 +226,25 @@
       },
       {
         "title": "Kraid Battle",
-        "pair": 31,
+        "paired_tracks": [
+          31
+        ],
         "fallback": 22,
         "description": "Extended track that plays during the Kraid battle. If not present, the Big Boss Battle 2 theme will be played."
       },
       {
         "title": "Phantoon Incoming",
-        "pair": 34,
+        "paired_tracks": [
+          34
+        ],
         "fallback": 23,
         "description": "Extended track that plays while Phantoon is appearing before the battle. Lasts about 10 seconds. If not present, the Tension / Hostile Incoming theme will be played."
       },
       {
         "title": "Phantoon Battle",
-        "pair": 33,
+        "paired_tracks": [
+          33
+        ],
         "fallback": 22,
         "description": "Extended track that plays during the Phantoon battle. If not present, the Big Boss Battle 2 theme will be played."
       },
@@ -241,13 +260,17 @@
       },
       {
         "title": "Baby Incoming",
-        "pair": 38,
+        "paired_tracks": [
+          38
+        ],
         "fallback": 23,
         "description": "Extended track that plays in the rooms that lead up to seeing the baby Metroid. If not present, the Tension / Hostile Incoming theme will be played."
       },
       {
         "title": "The Baby",
-        "pair": 37,
+        "paired_tracks": [
+          37
+        ],
         "fallback": 22,
         "description": "Extended track that plays when the baby Metroid shows up to drain Samus of her health. If not present, the Big Boss Battle 2 theme will be played."
       },

--- a/resources/snes/metroid3/manifests/tracks.json
+++ b/resources/snes/metroid3/manifests/tracks.json
@@ -128,6 +128,9 @@
       },
       {
         "title": "Big Boss Battle 1",
+        "paired_tracks": [
+          21
+        ],
         "notes": [
           "Bomb Torizo, Golden Torizo, Draygon & Ridley Battles",
           "Can be superceded by Expanded Soundtrack (35: Draygon/36: Ridley)",
@@ -142,6 +145,9 @@
       {
         "title": "Mysterious Statue Chamber",
         "name": "Chozo Statue Awakens",
+        "paired_tracks": [
+          19
+        ],
         "description": "Song played while Bomb Torizo is waking up. Plays for about 5.5 to 6 seconds unless someone pauses the game."
       },
       {

--- a/resources/snes/metroid3/manifests/tracks.json
+++ b/resources/snes/metroid3/manifests/tracks.json
@@ -9,7 +9,7 @@
         "name": "Samus Aran's Appearance Fanfare",
         "nonlooping": true,
         "special_track": true,
-        "description": "Song played when first starting at the ship or a save station before you can start moving. Does not loop and plays for about 8 seconds."
+        "description": "Song played when first starting at the ship or a save station before you can start moving. Does not loop and plays for about 6 seconds."
       },
       {
         "title": "Item Acquisition Fanfare",

--- a/resources/snes/metroid3/manifests/tracks.json
+++ b/resources/snes/metroid3/manifests/tracks.json
@@ -15,7 +15,7 @@
         "title": "Item Acquisition Fanfare",
         "nonlooping": true,
         "special_track": true,
-        "description": "Song played when you retrieve an item. Does not loop and plays for 6-7 seconds. Not used in SMZ3."
+        "description": "Song played when you retrieve an item. Does not loop and plays for 6-7 seconds. Not used in SMZ3 or SM Map Rando."
       },
       {
         "title": "Item room",
@@ -185,7 +185,7 @@
       },
       {
         "title": "Ceres Station",
-        "description": "Song played in the intro area of the game where you go to initially fight Ridley. Not used in SMZ3."
+        "description": "Song played in the intro area of the game where you go to initially fight Ridley. Not used in SMZ3 or SM Map Rando."
       },
       {
         "title": "Wrecked Ship Power Off",
@@ -286,11 +286,15 @@
         "notes": [
           "Mother Brain 3"
         ],
-        "description": "Extended track that plays during the Mother Brain battle after receiving the Hyper Beam from the baby Metroid. If not present, the Samus' Ship theme will be played."
+        "description": "Extended track that plays during the Mother Brain battle after receiving the Hyper Beam from the baby Metroid. If not present, the Samus' Ship theme will be played. Not used in SM Map Rando."
       },
       {
         "title": "Game Over",
-        "description": "Extended track that plays after the Samus Death Cry before loading from the last save point. If not present, ambient noise will be played."
+        "description": "Extended track that plays after the Samus Death Cry before loading from the last save point. If not present, ambient noise will be played. Not used in SM Map Rando."
+      },
+      {
+        "title": "Crateria (Storm Without Music)",
+        "description": "Thunder sound effects track that is played when near the ship in Crateria after Zebes is awake but before you have power bombs. Only used in the SM Map Rando."
       }
     ],
     "longest": 37,

--- a/resources/snes/zelda3/manifests/tracks.json
+++ b/resources/snes/zelda3/manifests/tracks.json
@@ -120,7 +120,10 @@
         "nonlooping": true,
         "notes": ["Should be 10 seconds"],
         "special_track": true,
-        "description": "Song played after defeating a boss, including Ganon. Should be 10.5 seconds as that's how long ALttPR will play no in race seeds. In non-race seeds, it will play until the end of the song. Does not loop."
+        "description": "Song played after defeating a boss, including Ganon. Should be 10.5 seconds as that's how long ALttPR will play no in race seeds. In non-race seeds, it will play until the end of the song. Does not loop.",
+        "paired_tracks": [
+          26
+        ]
       },
       {
         "title": "Sanctuary",
@@ -163,7 +166,10 @@
           "Full length plays in non-race ROMs",
           "About 1s plays in race ROMs"
         ],
-        "description": "Song played after the Boss Victory theme when getting a crystal. Loops in vanilla ALttP, but starts to fade out after 1-2 seconds and will play for 7.25 seconds in ALttPR and SMZ3."
+        "description": "Song played after the Boss Victory theme when getting a crystal. Loops in vanilla ALttP, but starts to fade out after 1-2 seconds and will play for 7.25 seconds in ALttPR and SMZ3.",
+        "paired_tracks": [
+          19
+        ]
       },
       {
         "title": "Fairy Fountain",
@@ -190,7 +196,7 @@
         "title": "Ganon's Theme",
         "name": "Ganon's Message",
         "paired_tracks": [
-          32
+          31
         ],
         "notes": ["Ganon's Monologue"],
         "description": "Song played when Ganon talks with you before the final fight."
@@ -199,7 +205,7 @@
         "title": "Ganon Fight",
         "name": "The Prince of Darkness",
         "paired_tracks": [
-          31
+          30
         ],
         "description": "Song played while fighting Ganon."
       },

--- a/resources/snes/zelda3/manifests/tracks.json
+++ b/resources/snes/zelda3/manifests/tracks.json
@@ -64,6 +64,7 @@
           "Should be 11 seconds"
         ],
         "nonlooping": true,
+        "special_track": true,
         "description": "Song played when receiving the item from the Master Sword pedestal. The sword will appear around 7.5 seconds, and the song lasts for around 11 seconds. Does not loop."
       },
       {
@@ -181,6 +182,7 @@
         "title": "Ganon Appears",
         "name": "Release of Ganon",
         "nonlooping": true,
+        "special_track": true,
         "notes": ["After Agahnim 2"],
         "description": "Song played after killing Aga 2. The full song plays for about 13 seconds before transitioning to the Dark World theme, but Ganon turns into a bat around 4 seconds in and Link plays the Ocarina at 8 seconds in. Does not loop."
       },

--- a/resources/snes/zelda3/manifests/tracks.json
+++ b/resources/snes/zelda3/manifests/tracks.json
@@ -9,6 +9,7 @@
         "name": "Link to the Past",
         "notes": ["Game Startup", "Should be 16 seconds"],
         "nonlooping": true,
+        "special_track": true,
         "description": "Song played when first booting up the game after the three Triforce pieces start flying in and goes into the title screen. Lasts for about 16.5 seconds and does not loop. Not used in SMZ3."
       },
       {

--- a/resources/snes/zelda3/manifests/tracks.json
+++ b/resources/snes/zelda3/manifests/tracks.json
@@ -442,7 +442,7 @@
           "Replaces track 2 after the pedestal item has been collected",
           "2: Light World Overworld"
         ],
-        "description": "Extended theme that replaces the Light World 2 theme after the Master Sword pedestal item has been retrieved."
+        "description": "Extended theme that replaces the Light World Overworld theme after the Master Sword pedestal item has been retrieved."
       },
       {
         "title": "Dark World 2",

--- a/resources/snes/zelda3/manifests/tracks.json
+++ b/resources/snes/zelda3/manifests/tracks.json
@@ -48,6 +48,7 @@
         "title": "Mirror Portal",
         "name": "Dimensional Shift",
         "nonlooping": true,
+        "special_track": true,
         "description": "Sound effect when using the mirror in the overworld. Lasts for 4-5 seconds depending on quick warp or not. Does not loop."
       },
       {
@@ -117,7 +118,8 @@
         "name": "Great Victory!",
         "nonlooping": true,
         "notes": ["Should be 10 seconds"],
-        "description": "Song played after defeating a boss, including Ganon. Should be 10.5 seconds as that's how long ALttPR will play no matter the length of the song. In non-race seeds, it will play until the end of the song. Does not loop."
+        "special_track": true,
+        "description": "Song played after defeating a boss, including Ganon. Should be 10.5 seconds as that's how long ALttPR will play no in race seeds. In non-race seeds, it will play until the end of the song. Does not loop."
       },
       {
         "title": "Sanctuary",
@@ -185,12 +187,18 @@
       {
         "title": "Ganon's Theme",
         "name": "Ganon's Message",
+        "paired_tracks": [
+          32
+        ],
         "notes": ["Ganon's Monologue"],
         "description": "Song played when Ganon talks with you before the final fight."
       },
       {
         "title": "Ganon Fight",
         "name": "The Prince of Darkness",
+        "paired_tracks": [
+          31
+        ],
         "description": "Song played while fighting Ganon."
       },
       {
@@ -217,127 +225,205 @@
       {
         "title": "Eastern Palace",
         "fallback": 17,
+        "paired_tracks": [
+          47
+        ],
         "description": "Extended theme for Eastern Palace. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Desert Palace",
         "fallback": 17,
+        "paired_tracks": [
+          48
+        ],
         "description": "Extended theme for Desert Palace. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Agahnim's Tower",
         "fallback": 16,
+        "paired_tracks": [
+          49
+        ],
         "description": "Extended theme for Agahnim's Tower. If not present, the Hyrule Castle theme will be played."
       },
       {
         "title": "Swamp Palace",
         "fallback": 22,
+        "paired_tracks": [
+          50
+        ],
         "description": "Extended theme for Swamp Palace. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Palace of Darkness",
         "fallback": 22,
+        "paired_tracks": [
+          51
+        ],
         "description": "Extended theme for Palace of Darkness. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Misery Mire",
         "fallback": 22,
+        "paired_tracks": [
+          52
+        ],
         "description": "Extended theme for Misery Mire. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Skull Woods",
         "fallback": 22,
+        "paired_tracks": [
+          53
+        ],
         "description": "Extended theme for Skull Woods. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Ice Palace",
         "fallback": 22,
+        "paired_tracks": [
+          54
+        ],
         "description": "Extended theme for Ice Palace. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Tower of Hera",
         "fallback": 17,
+        "paired_tracks": [
+          55
+        ],
         "description": "Extended theme for Tower of Hera. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Thieves' Town",
         "fallback": 22,
+        "paired_tracks": [
+          56
+        ],
         "description": "Extended theme for Thieves' Town. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Turtle Rock",
         "fallback": 22,
+        "paired_tracks": [
+          57
+        ],
         "description": "Extended theme for Turtle Rock. If not present, either the generic Light World or Dark World dungeon theme will play based off of the dungeon reward and game setting."
       },
       {
         "title": "Ganon's Tower",
         "fallback": 22,
+        "paired_tracks": [
+          58,
+          59
+        ],
         "description": "Extended theme for Ganon's Tower. If not present, the generic Dark World dungeon theme will be played."
       },
       {
         "title": "Eastern Palace Boss",
         "fallback": 21,
+        "paired_tracks": [
+          35
+        ],
         "description": "Extended theme for the Armos Knights. If not present, the generic boss theme will be played."
       },
       {
         "title": "Desert Palace Boss",
         "fallback": 21,
+        "paired_tracks": [
+          36
+        ],
         "description": "Extended theme for Lanmolas. If not present, the generic boss theme will be played."
       },
       {
         "title": "Agahnim's Tower Boss",
         "fallback": 21,
+        "paired_tracks": [
+          37
+        ],
         "description": "Extended theme for Agahnim 1. If not present, the generic boss theme will be played."
       },
       {
         "title": "Swamp Palace Boss",
         "fallback": 21,
+        "paired_tracks": [
+          38
+        ],
         "description": "Extended theme for Arrghus. If not present, the generic boss theme will be played."
       },
       {
         "title": "Palace of Darkness Boss",
         "fallback": 21,
+        "paired_tracks": [
+          39
+        ],
         "description": "Extended theme for the Helmasaur King. If not present, the generic boss theme will be played."
       },
       {
         "title": "Misery Mire Boss",
         "fallback": 21,
+        "paired_tracks": [
+          40
+        ],
         "description": "Extended theme for Vitreous. If not present, the generic boss theme will be played."
       },
       {
         "title": "Skull Woods Boss",
         "fallback": 21,
+        "paired_tracks": [
+          41
+        ],
         "description": "Extended theme for Mothula. If not present, the generic boss theme will be played."
       },
       {
         "title": "Ice Palace Boss",
         "fallback": 21,
+        "paired_tracks": [
+          42
+        ],
         "description": "Extended theme for Kholdstare. If not present, the generic boss theme will be played."
       },
       {
         "title": "Tower of Hera Boss",
         "fallback": 21,
+        "paired_tracks": [
+          43
+        ],
         "description": "Extended theme for Moldorm. If not present, the generic boss theme will be played."
       },
       {
         "title": "Thieves' Town Boss",
         "fallback": 21,
+        "paired_tracks": [
+          44
+        ],
         "description": "Extended theme for Blind. If not present, the generic boss theme will be played."
       },
       {
         "title": "Turtle Rock Boss",
         "fallback": 21,
+        "paired_tracks": [
+          45
+        ],
         "description": "Extended theme for Trinexx. If not present, the generic boss theme will be played."
       },
       {
         "title": "Ganon's Tower Boss",
         "fallback": 21,
+        "paired_tracks": [
+          46,
+          59
+        ],
         "description": "Extended theme for Agahnim 2. If not present, the generic boss theme will be played."
       },
       {
         "title": "Ganon's Tower 2",
         "fallback": 22,
         "remap": 46,
+        "paired_tracks": [
+          46,
+          58
+        ],
         "notes": ["Replaces track 46 for upstairs GT"],
         "description": "Extended theme that plays when heading upstairs in Ganon's Tower after obtaining the big key. If not present, it will fall back to either the Ganon's Tower theme or the generic Dark World theme if the GT theme is not present."
       },


### PR DESCRIPTION
- Someone requested the MSU Randomizer be able to pair Zelda dungeons and bosses, including Aga tower, Aga top, and Aga 1 fight. So, I changed pair to be an array.
- I added the option to shuffle tracks into positions they weren't originally designed for (say, the Mother Brain fight music could be the light world theme). However, some tracks are not well suited for this, such as item get tracks which may be short. For that purpose, I added the "special track" flag.